### PR TITLE
Implement basic Zustand store

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start"
+  },
+  "dependencies": {
+    "zustand": "^5.0.5"
   }
 }

--- a/store/useAppStore.ts
+++ b/store/useAppStore.ts
@@ -1,1 +1,49 @@
-// Placeholder: store logic here
+import { create } from 'zustand';
+
+/**
+ * Global application store.
+ *
+ * Usage:
+ * ```tsx
+ * const { dosages, addDose } = useAppStore();
+ * ```
+ */
+interface DoseEntry {
+  date: string;
+  amount: number;
+}
+
+interface WeightEntry {
+  date: string;
+  weight: number;
+}
+
+interface Projection {
+  targetDate: string;
+  expectedWeight: number;
+}
+
+interface AppState {
+  /** Recorded medication dosages */
+  dosages: DoseEntry[];
+  /** Logged weight entries */
+  weights: WeightEntry[];
+  /** Calculated weight projections */
+  projections: Projection[];
+
+  /** Add a new dose entry */
+  addDose: (entry: DoseEntry) => void;
+  /** Add a weight measurement */
+  addWeight: (entry: WeightEntry) => void;
+  /** Replace projection data */
+  setProjections: (projections: Projection[]) => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  dosages: [],
+  weights: [],
+  projections: [],
+  addDose: (entry) => set((state) => ({ dosages: [...state.dosages, entry] })),
+  addWeight: (entry) => set((state) => ({ weights: [...state.weights, entry] })),
+  setProjections: (projections) => set({ projections }),
+}));


### PR DESCRIPTION
## Summary
- add Zustand as a dependency
- create a basic global store for dosage, weight, and projections

## Testing
- `npm install`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a79a10e8832b9708f72faa0caced