### PR TITLE
Implement initial dashboard page

### DIFF
--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface PageLayoutProps {
+  children: React.ReactNode;
+}
+
+const PageLayout: React.FC<PageLayoutProps> = ({ children }) => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white shadow">
+        <div className="container mx-auto p-4">
+          <h1 className="text-2xl font-semibold">Weight Loss Planner</h1>
+        </div>
+      </header>
+      <main className="container mx-auto p-4">{children}</main>
+    </div>
+  );
+};
+
+export default PageLayout;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,1 +1,22 @@
-// Placeholder: entry point logic
+import React from 'react';
+import Head from 'next/head';
+import AdvancedHealthTools from '../components/AdvancedHealthTools';
+import DoseAndWeightCharts from '../components/DoseAndWeightCharts';
+import PageLayout from '../components/PageLayout';
+
+const HomePage: React.FC = () => {
+  return (
+    <PageLayout>
+      <Head>
+        <title>Health Dashboard</title>
+        <meta name="description" content="Track your weight loss progress" />
+      </Head>
+      <div className="space-y-8">
+        <DoseAndWeightCharts />
+        <AdvancedHealthTools />
+      </div>
+    </PageLayout>
+  );
+};
+
+export default HomePage;


### PR DESCRIPTION
## Summary
- replace placeholder home page with a React component
- add a simple layout wrapper for future customization
- lay out dashboard components on the page with metadata

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840a7972380832ba4d5ccc4acd38dad