### PR TITLE
Update gitignore for TypeScript incremental files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 out
 .DS_Store
 npm-debug.log*
+
+*.tsbuildinfo


### PR DESCRIPTION
## Summary
- ignore TypeScript build info files by default
- ensure no stray `tsconfig.tsbuildinfo` remains

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840afd425e4832bbc177bd7edd71ecb