### PR TITLE
Add user intake form

### DIFF
--- a/components/UserIntakeForm.tsx
+++ b/components/UserIntakeForm.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useAppStore, UserInfo } from '../store/useAppStore';
+
+const UserIntakeForm = () => {
+  const { setUserInfo } = useAppStore();
+  const [formData, setFormData] = useState<UserInfo>({
+    name: '',
+    email: '',
+    phone: '',
+    currentWeight: 0,
+    height: 0,
+    goalWeight: 0,
+    startDate: '',
+    gender: '',
+    age: undefined,
+    activityLevel: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: name === 'currentWeight' || name === 'height' || name === 'goalWeight' || name === 'age' ? Number(value) : value,
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setUserInfo(formData);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4 max-w-md mx-auto">
+      <h2 className="text-xl font-bold">Tell us about yourself</h2>
+      <input name="name" value={formData.name} onChange={handleChange} placeholder="Name" className="border p-2 w-full" />
+      <input name="email" value={formData.email} onChange={handleChange} placeholder="Email" className="border p-2 w-full" />
+      <input name="phone" value={formData.phone} onChange={handleChange} placeholder="Phone" className="border p-2 w-full" />
+      <input name="currentWeight" type="number" value={formData.currentWeight} onChange={handleChange} placeholder="Current weight" className="border p-2 w-full" />
+      <input name="height" type="number" value={formData.height} onChange={handleChange} placeholder="Height (inches)" className="border p-2 w-full" />
+      <input name="goalWeight" type="number" value={formData.goalWeight} onChange={handleChange} placeholder="Goal weight" className="border p-2 w-full" />
+      <input name="startDate" type="date" value={formData.startDate} onChange={handleChange} className="border p-2 w-full" />
+      <input name="gender" value={formData.gender} onChange={handleChange} placeholder="Gender" className="border p-2 w-full" />
+      <input name="age" type="number" value={formData.age ?? ''} onChange={handleChange} placeholder="Age" className="border p-2 w-full" />
+      <select name="activityLevel" value={formData.activityLevel} onChange={handleChange} className="border p-2 w-full">
+        <option value="">Activity level</option>
+        <option value="sedentary">Sedentary</option>
+        <option value="light">Light</option>
+        <option value="moderate">Moderate</option>
+        <option value="active">Active</option>
+      </select>
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">Continue</button>
+    </form>
+  );
+};
+
+export default UserIntakeForm;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,22 @@
 import Head from 'next/head';
 import DoseAndWeightCharts from '../components/DoseAndWeightCharts';
 import AdvancedHealthTools from '../components/AdvancedHealthTools';
-import { AppStoreProvider } from '../store/useAppStore';
+import UserIntakeForm from '../components/UserIntakeForm';
+import { AppStoreProvider, useAppStore } from '../store/useAppStore';
+
+function Dashboard() {
+  const { userInfo } = useAppStore();
+  if (!userInfo) {
+    return <UserIntakeForm />;
+  }
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <DoseAndWeightCharts />
+      <AdvancedHealthTools />
+    </main>
+  );
+}
 
 export default function Home() {
   return (
@@ -9,11 +24,7 @@ export default function Home() {
       <Head>
         <title>Weight Loss Planner Dashboard</title>
       </Head>
-      <main className="p-6">
-        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
-        <DoseAndWeightCharts />
-        <AdvancedHealthTools />
-      </main>
+      <Dashboard />
     </AppStoreProvider>
   );
 }

--- a/store/useAppStore.tsx
+++ b/store/useAppStore.tsx
@@ -1,10 +1,25 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
 interface HealthData {
   weightData: number[];
   doseData: number[];
   addWeight: (value: number) => void;
   addDose: (value: number) => void;
+  userInfo: UserInfo | null;
+  setUserInfo: (info: UserInfo) => void;
+}
+
+export interface UserInfo {
+  name: string;
+  email: string;
+  phone: string;
+  currentWeight: number;
+  height: number;
+  goalWeight: number;
+  startDate: string;
+  gender?: string;
+  age?: number;
+  activityLevel?: string;
 }
 
 const AppStoreContext = createContext<HealthData | undefined>(undefined);
@@ -12,12 +27,32 @@ const AppStoreContext = createContext<HealthData | undefined>(undefined);
 export function AppStoreProvider({ children }: { children: ReactNode }) {
   const [weightData, setWeightData] = useState<number[]>([180, 178, 176, 175]);
   const [doseData, setDoseData] = useState<number[]>([0.25, 0.25, 0.5, 0.5]);
+  const [userInfo, setUserInfoState] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('userInfo');
+      if (stored) {
+        try {
+          setUserInfoState(JSON.parse(stored));
+        } catch {
+          localStorage.removeItem('userInfo');
+        }
+      }
+    }
+  }, []);
 
   const addWeight = (value: number) => setWeightData(prev => [...prev, value]);
   const addDose = (value: number) => setDoseData(prev => [...prev, value]);
+  const setUserInfo = (info: UserInfo) => {
+    setUserInfoState(info);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('userInfo', JSON.stringify(info));
+    }
+  };
 
   return (
-    <AppStoreContext.Provider value={{ weightData, doseData, addWeight, addDose }}>
+    <AppStoreContext.Provider value={{ weightData, doseData, addWeight, addDose, userInfo, setUserInfo }}>
       {children}
     </AppStoreContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add `UserIntakeForm` component for onboarding
- extend `useAppStore` to persist user info
- show form on index until data is provided

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6840ae1109c8832bba5a02fc74020478